### PR TITLE
handle the case where object has additional properties

### DIFF
--- a/lib/swearjar.js
+++ b/lib/swearjar.js
@@ -12,7 +12,7 @@ var swearjar = {
       word = match[0];
       key  = word.toLowerCase();
 
-      if (key in this._badWords) {
+      if (key in this._badWords && Array.isArray(this._badWords[key])) {
         if (callback(word, match.index, this._badWords[key]) === false) {
           break;
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swearjar",
   "description": "Profanity detection and filtering library.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/raymondjavaxx/swearjar-node",
   "keywords": ["swear", "curse", "unallowed", "profanity", "clean", "filter", "badwords"],
   "author": {

--- a/test/test.js
+++ b/test/test.js
@@ -43,5 +43,20 @@ describe('swearjar.scorecard', function () {
       insult: 1
     });
   });
+});
 
+  describe('should handle object properties', function() {
+
+    it('should not return "should" as profane', function () {
+
+      Object.defineProperty(Object.prototype, 'should', {
+        set: function(){},
+        get: function(){
+          return this;
+        },
+        configurable: true
+      });
+
+      assert.equal(swearjar.profane('this should not be profane'), false);
+    });
 });


### PR DESCRIPTION
Hi,

We ran into an issue in our tests which use shouldjs.
Since the object has additional property, the word 'should' was being marked as profane.

Thanks
